### PR TITLE
UI-1205: fit-to-markers attribute of px-map does not work

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
-v3.5.0
+v3.5.2
+===================
+## Bug fixes:
+* Increment offset to getBoundsZoom() to fix fitToMarkers attribute of px-map doesn't work
+
+v3.5.1
 ===================
 ## New features:
 * Add `maxWidth` (Defaults to 400) and `minWidth` (Defaults to 300) property to

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -237,7 +237,7 @@
         return zoom;
       }
       if (fitSetting === 'max') {
-        let zoom = map.getBoundsZoom(bounds, true) - 1;
+        let zoom = map.getBoundsZoom(bounds, true) - 2;
         return zoom;
       }
     },

--- a/test/px-map-root-tests.js
+++ b/test/px-map-root-tests.js
@@ -394,7 +394,7 @@ describe('px-map with fit-to-markers enabled', function() {
       expect(callWithMin).to.eql(5); // should equal map.getMinZoom()
 
       var callWithMax = mapEl._getZoomLevelForFit(fakeBounds, 'max', fakeMap);
-      expect(callWithMax).to.eql(11); // should equal map.getBoundsZoom() - 1
+      expect(callWithMax).to.eql(10); // should equal map.getBoundsZoom() - 2
     });
 
     it('corretly sets its view', function() {


### PR DESCRIPTION
- Fix for fitToMarkers attribute of px-map does not work properly with a top down CRS, due to an open Leaflet [bug](https://github.com/Leaflet/Leaflet/issues/4172)