### PR TITLE
UI-2183 Popup info support html

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v3.6.0
+===================
+## New features:
+* Add custom HTML support for popup info. See `demo/px-map-popup-info-demo.html`.
+
 v3.5.2
 ===================
 ## Bug fixes:

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -65,7 +65,14 @@ limitations under the License.
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="42.3518414" lng="-71.0500149" type="info">
-            <px-map-popup-info min-width="200" title="{{props.title.value}}" description="{{props.description.value}}"></px-map-popup-info>
+            <px-map-popup-info min-width="200" title="{{props.title.value}}1233" description="{{props.description.value}}">
+            </px-map-popup-info>
+          </px-map-marker-static>
+          <px-map-marker-static lat="42.3518414" lng="-71.0510149" type="info">
+            <px-map-popup-info min-width="200">
+              <h3>Custom Header</h3>
+              <span>custom content custom content custom content custom content </span>
+            </px-map-popup-info>
           </px-map-marker-static>
         </px-map>
       </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-map-behavior-popup.es6.js
+++ b/px-map-behavior-popup.es6.js
@@ -417,7 +417,7 @@
               title || description
                 ? tmplFnIf(titleTmpl, title) +
                   tmplFnIf(descriptionTmpl, description)
-                : customContent.map(elem => elem.outerHTML)
+                : customContent.map(elem => elem.outerHTML).reduce((base, str) => base + str)
             }
           </div>
         </section>

--- a/px-map-behavior-popup.es6.js
+++ b/px-map-behavior-popup.es6.js
@@ -210,7 +210,8 @@
         title: this.title,
         description: this.description,
         imgSrc: this.imgSrc,
-        styleScope: this.isShadyScoped() ? this.getShadyScope() : undefined
+        styleScope: this.isShadyScoped() ? this.getShadyScope() : undefined,
+        customContent: this.getEffectiveChildren(),
       });
     }
   };
@@ -384,15 +385,15 @@
     _createPopup(settings={}) {
       // Assign settings and create content
       this.settings = settings;
-      const { title, description, imgSrc, styleScope, maxWidth, minWidth } = settings;
-      const content = this._generatePopupContent(title, description, imgSrc);
+      const { title, description, imgSrc, styleScope, maxWidth, minWidth, customContent } = settings;
+      const content = this._generatePopupContent(title, description, imgSrc, customContent);
       const className = `map-popup-info ${styleScope||''}`
 
-      this.initialize({ className, maxWidth, minWidth });
+      this.initialize({ className, maxWidth, minWidth, customContent });
       this.setContent(content);
     }
 
-    _generatePopupContent(title, description, imgSrc) {
+    _generatePopupContent(title, description, imgSrc, customContent) {
       let tmplFnIf = (fn, ...vals) =>
         vals.length && vals[0] !== undefined ? fn.call(this, ...vals) : '';
 
@@ -412,8 +413,12 @@
         <section class="map-box-info">
           ${tmplFnIf(imgTmpl, imgSrc)}
           <div class="map-box-info__content">
-            ${tmplFnIf(titleTmpl, title)}
-            ${tmplFnIf(descriptionTmpl, description)}
+            ${
+              title || description
+                ? tmplFnIf(titleTmpl, title) +
+                  tmplFnIf(descriptionTmpl, description)
+                : customContent.map(elem => elem.outerHTML)
+            }
           </div>
         </section>
       `;
@@ -421,8 +426,9 @@
 
     updateSettings(settings={}) {
       Object.assign(this.settings, settings);
-      const { title, description, imgSrc, styleScope } = this.settings;
-      const content = this._generatePopupContent(title, description, imgSrc);
+
+      const { title, description, imgSrc, customContent, styleScope } = this.settings;
+      const content = this._generatePopupContent(title, description, imgSrc, customContent);
 
       this.setContent(content);
       this.update();

--- a/px-map-behavior-popup.es6.js
+++ b/px-map-behavior-popup.es6.js
@@ -393,21 +393,30 @@
       this.setContent(content);
     }
 
-    _generatePopupContent(title, description, imgSrc, customContent) {
-      let tmplFnIf = (fn, ...vals) =>
+    _generatePopupContent(title, description, imgSrc, customContent = []) {
+      const tmplFnIf = (fn, ...vals) =>
         vals.length && vals[0] !== undefined ? fn.call(this, ...vals) : '';
 
-      let imgTmpl = (imgSrc) => `
+      const imgTmpl = (imgSrc) => `
         <div class="map-box-info__image">
           <img src="${imgSrc}" />
         </div>
       `;
-      let titleTmpl = (title) => `
+      const titleTmpl = (title) => `
         <p class="map-box-info__title">${title}</p>
       `;
-      let descriptionTmpl = (description) => `
+      const descriptionTmpl = (description) => `
         <p class="map-box-info__description">${description}</p>
       `;
+
+      const customContentArr = customContent.map(elem => elem.outerHTML);
+      let customContentStr;
+
+      if (customContentArr.length > 1) {
+        customContentStr = customContentArr.reduce((base, str) => base + str)
+      } else {
+        customContentStr = customContentArr[0]
+      }
 
       return `
         <section class="map-box-info">
@@ -417,7 +426,7 @@
               title || description
                 ? tmplFnIf(titleTmpl, title) +
                   tmplFnIf(descriptionTmpl, description)
-                : customContent.map(elem => elem.outerHTML).reduce((base, str) => base + str)
+                : customContentStr
             }
           </div>
         </section>

--- a/test/px-map-popup-tests.js
+++ b/test/px-map-popup-tests.js
@@ -47,6 +47,13 @@ describe('PxMap.InfoPopup class', function () {
     expect(content).to.include(DESCRIPTION_TEXT);
   });
 
+  it('constructor generates popup HTML with custom HTML', function() {
+    var mockDomList = [{ outerHTML: '<p>content</p>' }]
+    var popup = new PxMap.InfoPopup({ customContent: mockDomList });
+    var content = popup.getContent();
+    expect(content).to.include('<p>content</p>');
+  });
+
   it('constructor generates popup HTML with only an image link', function() {
     var IMG_LINK = 'https://test.test/foo.png';
     var popup = new PxMap.InfoPopup({ imgSrc: IMG_LINK });


### PR DESCRIPTION
Add custom html support to popup info

Web component:
```html
<px-map-popup-info>
  <h3>Custom Header</h3>
  <span>custom content custom content custom content custom content </span>
</px-map-popup-info>
```

React (ui-components-predix):
```jsx
<MapPopupInfo>
  <h3>Custom Header</h3>
  <span>custom content custom content custom content custom content </span>
</MapPopupInfo>
```
NOTE:
If `title` OR `description` is provided, the children will be ignored.
```jsx
<MapPopupInfo title="my-title">
  <p>custom content</p> // this will be ignored
</MapPopupInfo>
```

I already tested in `ui-components-predix` demo. Once this PR is merged, I'll start anther PR to `ui-components-predix`