### PR TITLE
UI-2406 Stop using object spread syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.9.0",
+  "version": "3.10.1",
   "description": "A lightweight framework for building interactive maps with web components",
   "main": [
     "px-map.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.9.0",
+  "version": "3.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.9.0",
+  "version": "3.10.1",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -187,7 +187,7 @@
       const customPopup = feature.customPopup;
 
       if (customPopup) {
-        const popup = new PxMap.InfoPopup({ ...customPopup });
+        const popup = new PxMap.InfoPopup(customPopup);
         return layer.bindPopup(popup);
       }
 

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -187,7 +187,7 @@
       const customPopup = feature.customPopup;
 
       if (customPopup) {
-        const popup = new PxMap.InfoPopup(customPopup);
+        const popup = new PxMap.InfoPopup(JSON.parse(JSON.stringify(customPopup)));
         return layer.bindPopup(popup);
       }
 


### PR DESCRIPTION
When I was testing layer geojson custom popup in predix demo, there was an console error.
```
ReferenceError: babelHelpers is not defined
```
That's because `px-map` only supports es6. However, the object spread syntax is es2018.

I don't know how to add support for es2018, so I just removed this syntax.