### PR TITLE
UI-2510: Marker Group: Marker is not able to highlight after data is updated

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+v3.15.3
+===================
+## Bug Fixes:
+* Fix Marker Group: Marker is not able to highlight after data is updated.
+* Turning off `animate` clusterConfig, due to zoom out and open popup issue.
+* Added demo to highlight after data is updated.
 
 v3.15.2
 ===================

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "description": "A lightweight framework for building interactive maps with web components",
   "main": [
     "px-map.html"

--- a/examples/marker-clusters-with-popups.html
+++ b/examples/marker-clusters-with-popups.html
@@ -72,6 +72,9 @@ limitations under the License.
       <li><button id="markerOne">Marker One</button></li>
       <li><button id="markerTwo">Marker Two</button></li>
       <li><button id="markerThree">Marker Three</button></li>
+      <li><button id="updateData">Update Data</button></li>
+      <li><button id="markerFour">Marker Four</button></li>
+      <li><button id="markerFive">Marker Five</button></li>
     </ul>
     <ul>
       <li><button id="markerCloseAllPopups">Marker - Close All Popups</button></li>
@@ -703,6 +706,76 @@ limitations under the License.
           }
         ]
       };
+      var featCollection1 = {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -121.9588851928711,
+                37.77926289427511
+              ]
+            },
+            "properties": {
+            "title": "Cabrillo National Monument",
+            "marker-icon": {
+              "icon-base": "static-icon",
+              "icon-type": "warning"
+            },
+            "marker-popup": {
+              "popup-base": "data-popup",
+              "popup-title": "Cabrillo National Monument",
+              "popup-data": {
+                "LAT": "37.77926289427511",
+                "LNG": "-121.9588851928711",
+                "STATE": "warning"
+              }
+            }
+          },
+          "id": "101"
+          },
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -121.9588851928711,
+                37.77926289427511
+              ]
+            },
+            "properties": {
+              "title": "Nobel Dr & Lebon Dr",
+              "marker-icon": { "icon-base": "static-icon", "icon-type": "unknown" }
+            },
+            "id": "102"
+          },
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -121.8929672241211,
+                37.734340111555134
+              ]
+            },
+            "properties": {
+              "title": "Cabrillo National Monument",
+              "marker-icon": {
+                "icon-base": "static-icon",
+                "icon-type": "warning"
+              },
+              "marker-popup" : {
+                "popup-base": "info-popup",
+                "popup-title": "Cabrillo National Monument",
+                "popup-description" : "Lorem ipsum dot sit amet, colloquas..."
+              }
+            },
+            "id": "103"
+          }
+        ]
+      };
       tmpl.mapMove = function(evt) {
         var markers = Polymer.dom(evt).rootTarget.getVisibleMarkers();
         console.log('There are ' + markers.length + ' markers visible on the map.');
@@ -748,6 +821,34 @@ limitations under the License.
       document.getElementById('markerThree').addEventListener('click', function() {
         const [LNG, LAT] = featCollection.features[5].geometry.coordinates;
         const { id } = featCollection.features[5];
+        if(!LAT || !LNG) return;
+        pxMap.lat = LAT;
+        pxMap.lng = LNG;
+        pxMap.zoom = 17; //single marker centered to map
+
+        pxMarkerGroup.opened = id;
+      });
+
+      // update data
+      document.getElementById('updateData').addEventListener('click', function() {
+        pxMarkerGroup.data = featCollection1;
+      });
+
+      // marker after data update(clustering)
+      document.getElementById('markerFour').addEventListener('click', function() {
+        const [LNG, LAT] = featCollection1.features[0].geometry.coordinates;
+        const { id } = featCollection1.features[0];
+        if(!LAT || !LNG) return;
+        pxMap.lat = LAT;
+        pxMap.lng = LNG;
+        pxMap.zoom = 17; //single marker centered to map
+
+        pxMarkerGroup.opened = id;
+      });
+      // marker after data update(non-clustering)
+      document.getElementById('markerFive').addEventListener('click', function() {
+        const [LNG, LAT] = featCollection1.features[2].geometry.coordinates;
+        const { id } = featCollection1.features[2];
         if(!LAT || !LNG) return;
         pxMap.lat = LAT;
         pxMap.lng = LNG;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-map-behavior-marker-group.es6.js
+++ b/px-map-behavior-marker-group.es6.js
@@ -282,6 +282,8 @@
 
     updateInst(lastOptions, nextOptions) {
       if (nextOptions.data) {
+        // Clear all markers and data, so you get the updated _markersRef
+        this._clearAllMarkersAndData(this.elementInst);
         const features = this._syncDataWithMarkers(nextOptions.data.features, this.elementInst);
         this._notifyNewFeatures(features);
       }
@@ -300,7 +302,10 @@
               // _fireEventOnMarkerOrVisibleParentCluster & _unspiderfyPreviousClusterIfNotParentOf
               this.async(() => {
                 // spiderfying only the clustered marker
-                if(selectedFeature.__parent._markers.length > 1) {
+                if(selectedFeature
+                    && selectedFeature.__parent
+                    && selectedFeature.__parent._markers
+                    && selectedFeature.__parent._markers.length > 1) {
                   this._fireEventOnMarkerOrVisibleParentCluster(selectedFeature);
                 } else {
                   this._bindAndOpenPopup(selectedFeature);
@@ -367,7 +372,9 @@
         maxClusterRadius: 150,
         spiderifyOnMaxZoom: true,
         removeOutsideVisibleBounds: true,
-        animate: true,
+        // After map zoom out, spidering not happening due to _inZoomAnimation returning true
+        // hence turning off the clustering animate
+        animate: false,
         polygonOptions: {
           stroke: true,
           color: this.getComputedStyleValue('--internal-px-map-marker-group-cluster-polygon-stroke-color'),
@@ -626,6 +633,7 @@
       clusterInst.clearLayers();
       this._features = null;
       this._markers = null;
+      this._markersRef = null;
     },
 
     /**
@@ -645,7 +653,12 @@
       const markersMap = this._markers = (this._markers || new WeakMap());
       const markersRef = this._markersRef = (this._markersRef || []);
 
-      const {featuresToAdd, featuresToUpdate, featuresToRemove, nextFeaturesSet, nextMarkersMap} = this._diffNewFeatures(newFeatures, featuresSet, markersMap);
+      const {
+        featuresToAdd,
+        featuresToUpdate,
+        featuresToRemove,
+        nextFeaturesSet,
+        nextMarkersMap } = this._diffNewFeatures(newFeatures, featuresSet, markersMap);
 
       let feature, cachedMarker, markersToOperate;
 


### PR DESCRIPTION
- Fix Marker Group: Marker is not able to highlight after data is updated.
- Turning off `animate` clusterConfig, due to map zoom out and open popup issue.
- Added demo to highlight after data is updated.