### PR TITLE
Add a default icon prop to Static marker for Static markers to work

### DIFF
--- a/demo/px-map-marker-custom-demo.html
+++ b/demo/px-map-marker-custom-demo.html
@@ -68,7 +68,7 @@ limitations under the License.
             <px-map-marker-custom lat="37.779927" text-color="red" lng="-121.978015" icon="px-nav:unconfirmed" stroke-color="blue" fill-color="white"
               icon-content="10">
             </px-map-marker-custom>
-            <px-map-marker-static lat="37.779927" lng="-121.978015"></px-map-marker-static>
+            <px-map-marker-static lat="37.779927" lng="-121.978015" type="info"></px-map-marker-static>
 
             <!-- Use the custom icon marker -->
             <px-map-marker-custom lat="37.752709" lng="-121.959926" icon="px-nav:unconfirmed" stroke-color="blue" fill-color="white"

--- a/px-map-behavior-marker.es6.js
+++ b/px-map-behavior-marker.es6.js
@@ -582,6 +582,11 @@
         reflectToAttribute: true,
         value: 'info',
         observer: '_updateMarkerIcon'
+      },
+      icon: {
+        type: String,
+        value: 'px-utl:location',
+        observer: '_updateMarkerIcon'
       }
     },
 
@@ -618,6 +623,7 @@
     _getMarkerIconOptions() {
       let options = {
         type: this.type || '',
+        icon: this.icon || '',
         styleScope: this.isShadyScoped() ? this.getShadyScope() : undefined
       };
 


### PR DESCRIPTION
- Problem 
- ```<MapMarkerStatic>``` was not working without the icon prop

From the predix code base it looks like the Static markers never worked without the icon prop, I added a default icon value so its not dependent on the app dev's to supply a value. 
![screen shot 2018-09-25 at 4 45 47 pm](https://user-images.githubusercontent.com/34457496/46049311-7ac9fd80-c0e2-11e8-9736-be539ef35088.png)
