### PR TITLE
Ui 2319 click area

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v3.15.4
+===================
+## Tweek / Enhancement:
+*  Make the weight to 7. The weight erlier was 5 and was still was uanble to click. 
+
 v3.15.3
 ===================
 ## Bug Fixes:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.15.3",
+  "version": "3.15.4",
   "description": "A lightweight framework for building interactive maps with web components",
   "main": [
     "px-map.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.15.3",
+  "version": "3.15.4",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -170,7 +170,7 @@
         radius: featureProperties.radius || attributeProperties.radius || 5,
         color: featureProperties.color || attributeProperties.color || '#3E87E8', // primary-blue,
         fillColor: featureProperties.fillColor || attributeProperties.fillColor || '#88BDE6', // $dv-light-blue
-        weight: featureProperties.weight || attributeProperties.weight || 5,
+        weight: featureProperties.weight || attributeProperties.weight || 7,
         opacity: featureProperties.opacity || attributeProperties.opacity || 1,
         fillOpacity: featureProperties.fillOpacity || attributeProperties.fillOpacity || 0.4,
       };
@@ -272,13 +272,13 @@
       objectToAppendHighlight = JSON.parse(JSON.stringify(featureObject));
 
       objectToAppendWeight.properties.style = {
-        weight: 5,
+        weight: 7,
         opacity: 0.7,
         color: currentRouteColor,
       };
 
       objectToAppendHighlight.properties.style = {
-        weight: 5,
+        weight: 7,
         color: 'rgba(0, 0, 0, 0.5)',
       };
 


### PR DESCRIPTION
Even after making a weight of '5' to the routes, the click area was too small and sometimes it was not possible to click on the route. 

Make the weight to 7