### PR TITLE
UI-2743: px-map-layer-geojson need to close the "custom" pop-up when data changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+v3.15.7
+===================
+## Bug Fixes:
+*  Fix: Reset _isHandleFeatureTapped flag after opening custom layer-geojson popup so, it does not
+   automatcially open the next custom popup.
+
 v3.15.6
 ===================
 ## Bug Fixes:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,7 @@
 v3.15.7
 ===================
 ## Bug Fixes:
-*  Fix: Reset _isHandleFeatureTapped flag after opening custom layer-geojson popup so, it does not
-   automatcially open the next custom popup.
+*  Fix: Reset _isHandleFeatureTapped flag after opening custom layer-geojson popup so, it does not automatcially open the next custom popup.
 
 v3.15.6
 ===================

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.15.6",
+  "version": "3.15.7",
   "description": "A lightweight framework for building interactive maps with web components",
   "main": [
     "px-map.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.15.6",
+  "version": "3.15.7",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -188,7 +188,9 @@
         if(this._isHandleFeatureTapped) {
           //wait until the map layer render
           setTimeout(() => {
-            return layer.bindPopup(popup).openPopup();
+            layer.bindPopup(popup).openPopup();
+            this._isHandleFeatureTapped = false;
+            return true;
           }, 0);
         }
       }
@@ -228,7 +230,6 @@
     _unbindPopup(layer) {
       if (typeof layer.getPopup() !== 'undefined') {
         layer.unbindPopup();
-        this._isHandleFeatureTapped = false;
       }
     },
 

--- a/px-map-behavior-layer-geojson.es6.js
+++ b/px-map-behavior-layer-geojson.es6.js
@@ -190,7 +190,6 @@
           setTimeout(() => {
             layer.bindPopup(popup).openPopup();
             this._isHandleFeatureTapped = false;
-            return true;
           }, 0);
         }
       }


### PR DESCRIPTION
*  Reset _isHandleFeatureTapped flag after opening custom layer-geojson popup so, it does not automatically open the next custom popup.