### PR TITLE
Toggle popup does not work after closing from map click

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v3.15.8
+===================
+## Bug Fixes:
+*  Fix: Toggle popup does not work after closing from map click.
+
 v3.15.7
 ===================
 ## Bug Fixes:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.15.7",
+  "version": "3.15.8",
   "description": "A lightweight framework for building interactive maps with web components",
   "main": [
     "px-map.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.15.7",
+  "version": "3.15.8",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-map-behavior-marker-group.es6.js
+++ b/px-map-behavior-marker-group.es6.js
@@ -965,11 +965,15 @@
       const klassName = (popupSettings._Base && PxMap.hasOwnProperty(popupSettings._Base)) ? popupSettings._Base : 'InfoPopup';
       const popup = new PxMap[klassName](popupSettings);
       marker.bindPopup(popup).openPopup();
-      marker.__boundCloseFn = this._unbindAndClosePopup.bind(this, marker);
-      marker.on('popupclose', marker.__boundCloseFn);
+      // otherwise causes multiple re-render of elementInst that loses the state
+      if(this.opened !== null) {
+        marker.__boundCloseFn = this._unbindAndClosePopup.bind(this, marker);
+        marker.on('popupclose', marker.__boundCloseFn);
+      }
 
-      // TODO: Investigate (JIRA:UI-2535) reason opened prop doesnt udpate/goes in loop.
-      // this.opened = marker.id;
+      // reset to clicked marker.id to retain true state opened prop
+      // after map interaction
+      this.opened = marker.id;
     },
 
     _unbindAndClosePopup(marker) {


### PR DESCRIPTION
- Fixed: Toggle popup does not work after closing from map click
- Steps to reproduce:
1.   Open popup from left-nav item click(opens popup)
2.   Click anywhere else on the map(closes popup)
3.   Click on Marker on map again(opens popup)
4.   Click markerCloseAllPopups left-nav(notice the toggle popup does not work)

**And, it works now.**