### PR TITLE
MAX-27732: Don't show the tooltip when openPopupOnSelect is false

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v3.19.28
+===================
+## Enhancement:
+* Don't show the popup for the marker when the `openPopupOnSelect` prop of `px-map-marker-group` is `FALSE` and is not triggered by marker clicking.
+
 v3.19.27
 ===================
 ## Enhancement:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-map",
-  "version": "3.19.27",
+  "version": "3.19.28",
   "description": "A lightweight framework for building interactive maps with web components",
   "main": [
     "px-map.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-map",
   "author": "General Electric",
   "description": "A lightweight framework for building interactive maps with web components",
-  "version": "3.19.27",
+  "version": "3.19.28",
   "private": false,
   "extName": null,
   "repository": {


### PR DESCRIPTION
https://servicemax.atlassian.net/browse/MAX-27732

Don't show the popup for the marker when the `openPopupOnSelect` prop of `px-map-marker-group` is `FALSE` and is not triggered by marker clicking.
